### PR TITLE
Change the way the games directory is detected closes #35

### DIFF
--- a/hbmame-merged-set-getter.sh
+++ b/hbmame-merged-set-getter.sh
@@ -77,7 +77,61 @@ if [ `grep -c "CURL_RETRY=" "${INIFILE_FIXED}"` -gt 0 ]
       CURL_RETRY=`grep "CURL_RETRY=" "${INIFILE_FIXED}" | awk -F "=" '{print$2}' | sed -e 's/^ *//' -e 's/ *$//' -e 's/^"//' -e 's/"$//'`
 fi 2>/dev/null
 
-mkdir -p ${ROMHBMAME}
+GAMESDIR_FOLDERS=( \
+    /media/usb0 \
+    /media/usb1 \
+    /media/usb2 \
+    /media/usb3 \
+    /media/usb4 \
+    /media/usb5 \
+    /media/usb0/games \
+    /media/usb1/games \
+    /media/usb2/games \
+    /media/usb3/games \
+    /media/usb4/games \
+    /media/usb5/games \
+    /media/fat/cifs \
+    /media/fat/cifs/games \
+    /media/fat \
+    /media/fat/games \
+)
+
+GETTER_DO()
+{
+    local SYSTEM="${1}"
+
+    shift
+
+    GET_SYSTEM_FOLDER "${SYSTEM}"
+    local SYSTEM_FOLDER="${GET_SYSTEM_FOLDER_RESULT}"
+    local GAMESDIR="${GET_SYSTEM_FOLDER_GAMESDIR}"
+
+    if [[ "${SYSTEM_FOLDER}" != "" ]]
+        then
+            ROMHBMAME="${GAMESDIR}/${SYSTEM}"
+            mkdir -p $ROMHBMAME
+    fi	
+}
+
+GET_SYSTEM_FOLDER_GAMESDIR=
+GET_SYSTEM_FOLDER_RESULT=
+GET_SYSTEM_FOLDER()
+{
+    GET_SYSTEM_FOLDER_GAMESDIR="/media/fat/games"
+    GET_SYSTEM_FOLDER_RESULT=
+    local SYSTEM="${1}"
+    for folder in ${GAMESDIR_FOLDERS[@]}
+    do
+        local RESULT=$(find "${folder}" -maxdepth 1 -type d -iname "${SYSTEM}" -printf "%P\n" -quit 2> /dev/null)
+        if [[ "${RESULT}" != "" ]] ; then
+            GET_SYSTEM_FOLDER_GAMESDIR="${folder}"
+            GET_SYSTEM_FOLDER_RESULT="${RESULT}"
+            break
+        fi
+    done
+}
+
+GETTER_DO hbmame
 
 #####INFO TXT#####
 

--- a/mame-merged-set-getter.sh
+++ b/mame-merged-set-getter.sh
@@ -74,7 +74,61 @@ if [ `grep -c "CURL_RETRY=" "${INIFILE_FIXED}"` -gt 0 ]
       CURL_RETRY=`grep "CURL_RETRY=" "${INIFILE_FIXED}" | awk -F "=" '{print$2}' | sed -e 's/^ *//' -e 's/ *$//' -e 's/^"//' -e 's/"$//'`
 fi 2>/dev/null
 
-mkdir -p ${ROMMAME}
+GAMESDIR_FOLDERS=( \
+    /media/usb0 \
+    /media/usb1 \
+    /media/usb2 \
+    /media/usb3 \
+    /media/usb4 \
+    /media/usb5 \
+    /media/usb0/games \
+    /media/usb1/games \
+    /media/usb2/games \
+    /media/usb3/games \
+    /media/usb4/games \
+    /media/usb5/games \
+    /media/fat/cifs \
+    /media/fat/cifs/games \
+    /media/fat \
+    /media/fat/games \
+)
+
+GETTER_DO()
+{
+    local SYSTEM="${1}"
+
+    shift
+
+    GET_SYSTEM_FOLDER "${SYSTEM}"
+    local SYSTEM_FOLDER="${GET_SYSTEM_FOLDER_RESULT}"
+    local GAMESDIR="${GET_SYSTEM_FOLDER_GAMESDIR}"
+
+    if [[ "${SYSTEM_FOLDER}" != "" ]]
+        then
+            ROMMAME="${GAMESDIR}/${SYSTEM}"
+            mkdir -p $ROMMAME
+    fi	
+}
+
+GET_SYSTEM_FOLDER_GAMESDIR=
+GET_SYSTEM_FOLDER_RESULT=
+GET_SYSTEM_FOLDER()
+{
+    GET_SYSTEM_FOLDER_GAMESDIR="/media/fat/games"
+    GET_SYSTEM_FOLDER_RESULT=
+    local SYSTEM="${1}"
+    for folder in ${GAMESDIR_FOLDERS[@]}
+    do
+        local RESULT=$(find "${folder}" -maxdepth 1 -type d -iname "${SYSTEM}" -printf "%P\n" -quit 2> /dev/null)
+        if [[ "${RESULT}" != "" ]] ; then
+            GET_SYSTEM_FOLDER_GAMESDIR="${folder}"
+            GET_SYSTEM_FOLDER_RESULT="${RESULT}"
+            break
+        fi
+    done
+}
+
+GETTER_DO mame
 
 #####INFO TXT#####
 


### PR DESCRIPTION
When you move your mame and hbmame roms to a USB drive, Mister will, occasionally attach it to usb1 instead of usb0, when this happens, these scripts freak out and redownload every rom to /media/fat/games, I noticed that the BIOS downloader doesn't do this, it gracefully find the games directory on USB1, and does what it needs to do, with no problem, so, I went through the code, and found how it accomplished this feat, and, modified it a bit, in order to add it to both of these scripts. One future update I would like to do is add support for having a truly custom location, such as /media/usb0/Arcade/mame, or, whatever, and still have it work. I actually already added that feature to a previous version that was accidentally erased when the directory I was working in (/tmp) was wiped by a reboot, but, it wasn't done very cleanly, and, i had to redo this whole thing, and just didn't feel like continuing to fool with it, right now. Also, even though I didn't remove the code that handles a custom path in the ini file, this pretty much negates that feature, for now. As long as your roms are located in any of the directories listed in the GAMESDIR_FOLDERS array, it will still work fine.