### PR TITLE
add missing cifs-path for system-folder-detection

### DIFF
--- a/hbmame-merged-set-getter.sh
+++ b/hbmame-merged-set-getter.sh
@@ -84,6 +84,7 @@ GAMESDIR_FOLDERS=( \
     /media/usb3/games \
     /media/usb4/games \
     /media/usb5/games \
+    /media/fat/cifs \
     /media/fat/cifs/games \
     /media/fat/games \
 )

--- a/mame-merged-set-getter.sh
+++ b/mame-merged-set-getter.sh
@@ -81,6 +81,7 @@ GAMESDIR_FOLDERS=( \
     /media/usb3/games \
     /media/usb4/games \
     /media/usb5/games \
+    /media/fat/cifs \
     /media/fat/cifs/games \
     /media/fat/games \
 )


### PR DESCRIPTION
Hi there,

The "plain" CIFS-path (without the "games" subdirectory) is missing here; which should be the preferred standard use-case.

Compare to:

https://github.com/theypsilon/MiSTer_BIOS_SCRIPTS/blob/78631ad379acd65ab41a92e1d823c1ae73cecc1c/bios-getter.sh#L88-L105

Just found out that the updater won't work for me in its current state; putting the ROMs on the SD-Card (instead on the CIFS-share).

This PR should fix it.

Thanks!