### PR TITLE
hbmame: add 0.228 & 0.229 & 0.230

### DIFF
--- a/hbmame-merged-set-getter.sh
+++ b/hbmame-merged-set-getter.sh
@@ -214,6 +214,15 @@ download_hbmame_roms_from_mra() {
 	    '0227')
                   curl ${CURL_RETRY} ${SSL_SECURITY_OPTION} --fail --location -o "${ZIP_PATH}" "https://archive.org/download/HBmame0.227-romsmerged/${f}"
                      ;;
+	    '0228')
+                  curl ${CURL_RETRY} ${SSL_SECURITY_OPTION} --fail --location -o "${ZIP_PATH}" "https://archive.org/download/HBmame0.228-romsmerged/${f}"
+                     ;;	
+	    '0229')
+                  curl ${CURL_RETRY} ${SSL_SECURITY_OPTION} --fail --location -o "${ZIP_PATH}" "https://archive.org/download/HBmame0.229-romsmerged/${f}"
+                     ;;
+	    '0230')
+                  curl ${CURL_RETRY} ${SSL_SECURITY_OPTION} --fail --location -o "${ZIP_PATH}" "https://archive.org/download/HBmame0.230-romsmerged/${f}"
+                     ;;
 	   	
             *)
                   echo "MAME version not listed in MRA or there is no download source for the version, downloading from .220 set"


### PR DESCRIPTION
This should clear up just a few occasional hiccups, in theory. Unfortunately there isn't anything on the archive for 0.231-0.244 yet, users are running into issues with some sf2ce.zip hbmame roms not working for them by default. Like the latest sf2mix for instance, just helped someone with that and decided to take a look.

If adding these isn't valuable in your experience, that's okay to deny the request too of course.